### PR TITLE
Harden acps-sha skill tar excludes

### DIFF
--- a/.claude/skills/acps-sha/SKILL.md
+++ b/.claude/skills/acps-sha/SKILL.md
@@ -30,6 +30,7 @@ Both land in the local `releases/orion-<stamp>/` directory — which is **gitign
    STAMP=$(date +%Y_%m_%d_%H_%M)
    mkdir -p "releases/orion-$STAMP"
    tar -czf "releases/orion-$STAMP/orion-$STAMP.tar.gz" --uid 0 --gid 0 \
+       --exclude '.DS_Store' --exclude '__pycache__' \
        troubleshooter.sh tools.conf README.md scripts
    ```
 


### PR DESCRIPTION
Adds --exclude '.DS_Store' --exclude '__pycache__' to the release tar command so stray Finder metadata and Python bytecode caches can never ship in an ACPS package.